### PR TITLE
Use stdio option instead of customFds

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (opts, cb) {
       || 'more'
     
     setRaw(true);
-    var ps = spawn(pager, opts.args || [], { customFds : [ null, 1, 2 ] });
+    var ps = spawn(pager, opts.args || [], { stdio : [ null, 1, 2 ] });
     
     ps.on('exit', function (code, sig) {
         setRaw(false);

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
         "url" : "http://substack.net"
     },
     "license" : "MIT",
-    "engine" : { "node" : ">=0.6" }
+    "engine" : { "node" : ">=0.8" }
 }


### PR DESCRIPTION
`customFds` is deprecated on Node 0.12 and iojs.

```
child_process: customFds option is deprecated, use stdio instead.
```