### PR TITLE
Ignore EPIPE from pager process

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (opts, cb) {
     });
 
     ps.stdin.on('error', function (e) {
-        if (!e.errno || e.errno !== 'EPIPE') { throw(e); }
+        // Ignore EPIPE and ECONNRESET.
     });
 
     return ps.stdin

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ module.exports = function (opts, cb) {
         if (typeof cb === 'function') cb(code, sig)
     });
 
+    ps.stdin.on('error', function (e) {
+        if (!e.errno || e.errno !== 'EPIPE') { throw(e); }
+    });
+
     return ps.stdin
 };
 


### PR DESCRIPTION
See also denysdovhan/bash-handbook#51 and denysdovhan/bash-handbook#46.

While this change achieves the goal of ignoring EPIPE (caused by quitting the pager; not a cause for concern), it makes handling any other errors more difficult. I'm not sure how best to do this with node.js.

Ideally, we could detect and ignore EPIPE then handle all other errors in the same way as `EventEmitter.prototype.emit`: call 'error' event handlers if present, throw the Error otherwise. This may be an appropriate use for [Domain](https://nodejs.org/api/domain.html), but this module is deprecated and I'm not aware of a replacement.
