### PR TITLE
Add `defaultPager` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function (opts, cb) {
     
     var pager = opts.pager 
       || process.env.PAGER 
+      || opts.defaultPager
       || 'more'
     
     setRaw(true);


### PR DESCRIPTION
See also denysdovhan/bash-handbook#46.

This PR adds a `defaultPager` option (perhaps we could give this a better, less ambiguous name) to allow overriding the default of `more`. The difference between `defaultPager` and `pager` is that `pager` takes precedence over the `$PAGER` environment variable, whereas `defaultPager` is only used when `$PAGER` is not set.