### PR TITLE
Handle $PAGER being a command with args

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,16 @@ module.exports = function (opts, cb) {
       || process.env.PAGER 
       || 'more'
 
+    opts.args || (opts.args = []);
+
     if (pager.indexOf(' ') > 0) {
         var pagerAndArgs = pager.split(/\s+/);
-        pager = pagerAndArgs[0]
-        opts.args = pagerAndArgs.slice(1)
+        pager = pagerAndArgs[0];
+        Array.prototype.push.apply(opts.args, pagerAndArgs.slice(1));
     }
     
     setRaw(true);
-    var ps = spawn(pager, opts.args || [], { stdio : [ null, 1, 2 ] });
+    var ps = spawn(pager, opts.args, { stdio : [ null, 1, 2 ] });
     
     ps.on('exit', function (code, sig) {
         setRaw(false);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,12 @@ module.exports = function (opts, cb) {
     var pager = opts.pager 
       || process.env.PAGER 
       || 'more'
+
+    if (pager.indexOf(' ') > 0) {
+        var pagerAndArgs = pager.split(/\s+/);
+        pager = pagerAndArgs[0]
+        opts.args = pagerAndArgs.slice(1)
+    }
     
     setRaw(true);
     var ps = spawn(pager, opts.args || [], { stdio : [ null, 1, 2 ] });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.0",
   "description": "launch $PAGER in your program",
   "main": "index.js",
+  "scripts": {
+      "test": "node test.js"
+  },
   "bin": {},
   "dependencies": {},
   "repository": {
@@ -23,5 +26,8 @@
   "license": "MIT",
   "engine": {
     "node": ">=0.8"
+  },
+  "devDependencies": {
+    "tape": "^4.6.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,55 @@
+var test = require('tape');
+var async = require('async');
+
+mockSpawn = {
+    on: function() {},
+    stdin: { on: function() {} },
+};
+
+test("$PAGER unset", function(t) {
+    require('child_process').spawn = function(cmd, args, opts) {
+        t.equals(cmd, "more", "Use 'more' unless $PAGER is set");
+        t.deepEquals(args, [], "No args unless $PAGER is set");
+        return mockSpawn;
+    };
+    delete process.env.PAGER;
+    require('.')();
+    t.end();
+    delete require.cache[require.resolve('.')]
+});
+
+test("$PAGER set to 'less'", function(t) {
+    require('child_process').spawn = function(cmd, args, opts) {
+        t.equals(cmd, "less", "Use 'less' if $PAGER == 'less'");
+        t.deepEquals(args, [], "No args for $PAGER == 'less'");
+        return mockSpawn;
+    };
+    process.env.PAGER = 'less';
+    require('.')();
+    delete require.cache[require.resolve('.')]
+    t.end();
+});
+
+test("$PAGER set to 'less -Rs'", function(t) {
+    require('child_process').spawn = function(cmd, args, opts) {
+        t.equals(cmd, "less", "Use 'less' if $PAGER == 'less -Rs'");
+        t.deepEquals(args, ['-Rs'], "args: ['-Rs'] for $PAGER == 'less -Rs'");
+        return mockSpawn;
+    };
+    process.env.PAGER = 'less -Rs';
+    require('.')();
+    delete require.cache[require.resolve('.')]
+    t.end();
+});
+
+test("$PAGER set to 'less -Rs' plus opt.args", function(t) {
+    require('child_process').spawn = function(cmd, args, opts) {
+        t.equals(cmd, "less", "Use 'less' if $PAGER == 'less -Rs'");
+        t.deepEquals(args, ['foo', '-Rs'], "args: ['foo', '-Rs'] for $PAGER == 'less -Rs' and opt.args == ['foo']");
+        return mockSpawn;
+    };
+    process.env.PAGER = 'less -Rs';
+    require('.')({args: ['foo']});
+    delete require.cache[require.resolve('.')]
+    t.end();
+});


### PR DESCRIPTION
If `$PAGER` is set to a command with arguments (e.g. `less -Rs`),
default-pager tried to execute the whole call as a binary. With this
change, the `$PAGER` call will be split into command and arguments.

It's still rather naive, won't handle arguments with escaped spaces or
in quotes but it works for single-character arguments such as those used
by `less`.
